### PR TITLE
Specify individual PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ You must provide a valid [GitHub API token](https://github.com/settings/tokens),
 - An environment variable called `GH_GH_PAT`;
 - Or by passing it as an argument to the `-t` or `--token` command-line arguments.
 
-Pull request results may optionally be scoped by repository. Specify `-r` or `--repo` several times to only include pull requests within the named repositories.
-If omitted, results from _all_ repositories will be included, unless a `GITHUB_REPOSITORY` environment variable is present and non-empty (such as within a Codespace), in which case its value will be used.
+Queried pull requests may optionally be scoped by repository or specified individually. Specify `-r` or `--repo` several times to only include pull requests within the named repositories. Use `-p` or `--pull-request` to indicate pull requests individually, using either the full pull request URL for your browser (`https://github.com/smashwilson/pr-status/pull/123`; any subpage will work) or a short reference string (`smashwilson/pr-status#123`).
+
+If omitted and a `GITHUB_REPOSITORY` environment variable is present and non-empty (such as within a Codespace), its value will be used.
 
 Otherwise, here's the usage:
 
 ```
-Usage: pr status [options] [command]
+Usage: pr-status [options] [command]
 
 Commands:
   help     Display help
@@ -32,6 +33,7 @@ Commands:
 
 Options:
   -h, --help         Output usage information
+  -p, --pull-request <list>  Limit results to individually identified pull requests (defaults to [])
   -r, --repo <list>  Limit results to PRs in this repo (defaults to [])
   -t, --token        GitHub API token used for queries (defaults to "")
   -v, --verbose      Include successful builds in output (disabled by default)

--- a/lib/graphQL.ts
+++ b/lib/graphQL.ts
@@ -2,7 +2,7 @@ import type {Response} from "node-fetch";
 import fetch from "node-fetch";
 
 export interface Variables {
-  [name: string]: string | string[] | null;
+  [name: string]: string | string[] | number | null;
 }
 
 export interface ServerError extends Error {

--- a/lib/invocation.ts
+++ b/lib/invocation.ts
@@ -116,10 +116,8 @@ export class Invocation {
     args: string[]
   ): PullRequestDesignator[] {
     return args.flatMap((arg) => {
-      console.log(`testing: ${arg}`);
       const pullUrlMatch = PULL_URL_RX.exec(arg);
       if (pullUrlMatch) {
-        console.log("pullUrlMatch", pullUrlMatch);
         return [
           {
             owner: pullUrlMatch[1],
@@ -131,7 +129,6 @@ export class Invocation {
 
       const pullShortMatch = PULL_SHORT_RX.exec(arg);
       if (pullShortMatch) {
-        console.log("pullShortMatch", pullShortMatch);
         return [
           {
             owner: pullShortMatch[1],

--- a/lib/invocation.ts
+++ b/lib/invocation.ts
@@ -12,9 +12,20 @@ export interface OutputWriter {
   write(str: string): void;
 }
 
+interface PullRequestDesignator {
+  owner: string;
+  name: string;
+  number: number;
+}
+
+const PULL_URL_RX = /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/;
+
+const PULL_SHORT_RX = /^([^/]+)\/([^#]+)#(\d+)$/;
+
 export class Invocation {
   token: string;
   repos: string[];
+  pullRequests: PullRequestDesignator[];
   wait: boolean;
   verbose: boolean;
   graphql: GraphQL;
@@ -25,11 +36,13 @@ export class Invocation {
     output: OutputWriter,
     token: string,
     repos: string[] = [],
+    pullRequests: PullRequestDesignator[] = [],
     wait: false,
     verbose: false
   ) {
     this.token = token;
     this.repos = repos;
+    this.pullRequests = pullRequests;
     this.wait = wait;
     this.verbose = verbose;
     this.graphql = graphql;
@@ -40,6 +53,11 @@ export class Invocation {
     args
       .option(["t", "token"], "GitHub API token used for queries", "")
       .option(["r", "repo"], "Limit results to PRs in this repo", [])
+      .option(
+        ["p", "pull-request"],
+        "Limit results to individually identified pull requests",
+        []
+      )
       .option(["w", "wait"], "Poll for updates", false)
       .option(["v", "verbose"], "Include successful builds in output", false);
     const flags = args.parse(argv);
@@ -56,9 +74,25 @@ export class Invocation {
       throw error;
     }
 
+    const pullRequests: PullRequestDesignator[] =
+      this.parsePullRequestDesignatorsFrom(flags.p);
+    if (pullRequests.length !== flags.p.length) {
+      console.error("Pull requests may be specified by URL or reference text:");
+      console.error("- https://github.com/repo/name/pull/1234");
+      console.error("- repo/name#1234");
+
+      const error = new Error(
+        "Unable to parse pull request"
+      ) as TerminationError;
+      error.exitCode = 1;
+      throw error;
+    }
+
     const repos: string[] = flags.repo;
+
     if (
       repos.length === 0 &&
+      pullRequests.length === 0 &&
       env.GITHUB_REPOSITORY &&
       env.GITHUB_REPOSITORY.length > 0
     ) {
@@ -72,9 +106,43 @@ export class Invocation {
       process.stdout,
       token,
       repos,
+      pullRequests,
       flags.wait,
       flags.verbose
     );
+  }
+
+  private static parsePullRequestDesignatorsFrom(
+    args: string[]
+  ): PullRequestDesignator[] {
+    return args.flatMap((arg) => {
+      console.log(`testing: ${arg}`);
+      const pullUrlMatch = PULL_URL_RX.exec(arg);
+      if (pullUrlMatch) {
+        console.log("pullUrlMatch", pullUrlMatch);
+        return [
+          {
+            owner: pullUrlMatch[1],
+            name: pullUrlMatch[2],
+            number: parseInt(pullUrlMatch[3], 10),
+          },
+        ];
+      }
+
+      const pullShortMatch = PULL_SHORT_RX.exec(arg);
+      if (pullShortMatch) {
+        console.log("pullShortMatch", pullShortMatch);
+        return [
+          {
+            owner: pullShortMatch[1],
+            name: pullShortMatch[2],
+            number: parseInt(pullShortMatch[3], 10),
+          },
+        ];
+      }
+
+      return [];
+    });
   }
 
   execute(): Promise<void> {

--- a/lib/service/pullRequestLocator.ts
+++ b/lib/service/pullRequestLocator.ts
@@ -95,6 +95,7 @@ export class PullRequestLocator {
           owner: owner,
           name: name,
           number: number,
+          rollupCursor: null,
         }
       );
 

--- a/lib/service/pullRequestLocator.ts
+++ b/lib/service/pullRequestLocator.ts
@@ -18,7 +18,10 @@ import {
   isStatusContext,
   StatusCheckRollupFragment,
 } from "./queries/statusCheckRollupFragment.js";
-import { pullRequestByNumberQuery, PullRequestByNumberResponse } from "./queries/pullRequestByNumber.js";
+import {
+  pullRequestByNumberQuery,
+  PullRequestByNumberResponse,
+} from "./queries/pullRequestByNumber.js";
 
 interface RollupPageRequest {
   rollupId: string;
@@ -80,15 +83,20 @@ export class PullRequestLocator {
     return pullRequests;
   }
 
-  async byNumber(owner: string, name: string, number: number): Promise<PullRequest | null> {
-    const pullRequestData = await this.graphql.query<PullRequestByNumberResponse>(
-      pullRequestByNumberQuery,
-      {
-        owner: owner,
-        name: name,
-        number: number,
-      }
-    );
+  async byNumber(
+    owner: string,
+    name: string,
+    number: number
+  ): Promise<PullRequest | null> {
+    const pullRequestData =
+      await this.graphql.query<PullRequestByNumberResponse>(
+        pullRequestByNumberQuery,
+        {
+          owner: owner,
+          name: name,
+          number: number,
+        }
+      );
 
     const node = pullRequestData.repository?.pullRequest;
     if (!node) {
@@ -107,15 +115,19 @@ export class PullRequestLocator {
       node.isDraft,
       this.statuses(rollup),
       this.requestedReviews(node)
-    )
+    );
 
     const rollupPageInfo = rollup?.contexts.pageInfo;
     if (rollup && rollupPageInfo?.hasNextPage) {
-      await this.collectRollupPages(new Set([{
-        rollupId: rollup.id,
-        rollupCursor: rollupPageInfo.endCursor,
-        pullRequest,
-      }]));
+      await this.collectRollupPages(
+        new Set([
+          {
+            rollupId: rollup.id,
+            rollupCursor: rollupPageInfo.endCursor,
+            pullRequest,
+          },
+        ])
+      );
     }
 
     return pullRequest;

--- a/lib/service/pullRequestLocator.ts
+++ b/lib/service/pullRequestLocator.ts
@@ -18,6 +18,7 @@ import {
   isStatusContext,
   StatusCheckRollupFragment,
 } from "./queries/statusCheckRollupFragment.js";
+import { pullRequestByNumberQuery, PullRequestByNumberResponse } from "./queries/pullRequestByNumber.js";
 
 interface RollupPageRequest {
   rollupId: string;
@@ -77,6 +78,47 @@ export class PullRequestLocator {
     await this.collectRollupPages(rollupPages);
 
     return pullRequests;
+  }
+
+  async byNumber(owner: string, name: string, number: number): Promise<PullRequest | null> {
+    const pullRequestData = await this.graphql.query<PullRequestByNumberResponse>(
+      pullRequestByNumberQuery,
+      {
+        owner: owner,
+        name: name,
+        number: number,
+      }
+    );
+
+    const node = pullRequestData.repository?.pullRequest;
+    if (!node) {
+      return null;
+    }
+
+    const rollup = node.commits.nodes[0].commit.statusCheckRollup;
+
+    const pullRequest = new PullRequest(
+      node.id,
+      node.baseRepository.owner.login,
+      node.baseRepository.name,
+      node.number,
+      node.title,
+      node.url,
+      node.isDraft,
+      this.statuses(rollup),
+      this.requestedReviews(node)
+    )
+
+    const rollupPageInfo = rollup?.contexts.pageInfo;
+    if (rollup && rollupPageInfo?.hasNextPage) {
+      await this.collectRollupPages(new Set([{
+        rollupId: rollup.id,
+        rollupCursor: rollupPageInfo.endCursor,
+        pullRequest,
+      }]));
+    }
+
+    return pullRequest;
   }
 
   private requestedReviews(

--- a/lib/service/queries/pullRequestByNumber.ts
+++ b/lib/service/queries/pullRequestByNumber.ts
@@ -4,7 +4,7 @@ import {
 } from "./pullRequestFragment.js";
 
 export const pullRequestByNumberQuery = `
-query($owner: String!, $name: String!, $number: Int!) {
+query($owner: String!, $name: String!, $number: Int!, $rollupCursor: String) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
       ...pullRequestFragment

--- a/lib/service/queries/pullRequestByNumber.ts
+++ b/lib/service/queries/pullRequestByNumber.ts
@@ -1,0 +1,22 @@
+import {
+  PullRequestFragment,
+  pullRequestFragment,
+} from "./pullRequestFragment.js";
+
+export const pullRequestByNumberQuery = `
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      ...pullRequestFragment
+    }
+  }
+}
+
+${pullRequestFragment}
+`;
+
+export interface PullRequestByNumberResponse {
+  repository: {
+    pullRequest: PullRequestFragment;
+  };
+}

--- a/lib/service/queries/pullRequestFragment.ts
+++ b/lib/service/queries/pullRequestFragment.ts
@@ -56,7 +56,7 @@ fragment pullRequestFragment on PullRequest {
 }
 
 ${statusCheckRollupFragment}
-`
+`;
 
 export interface PullRequestFragment {
   id: string;

--- a/lib/service/queries/pullRequestFragment.ts
+++ b/lib/service/queries/pullRequestFragment.ts
@@ -1,0 +1,100 @@
+import {ReviewState} from "../../model/review.js";
+import {
+  StatusCheckRollupFragment,
+  statusCheckRollupFragment,
+} from "./statusCheckRollupFragment.js";
+
+export const pullRequestFragment = `
+fragment pullRequestFragment on PullRequest {
+  id
+  isDraft
+  number
+  title
+  url
+  baseRepository {
+    name
+    owner {
+      login
+    }
+  }
+
+  # Reviews
+
+  reviews(first: 20) {
+    nodes {
+      author {
+        login
+      }
+      state
+      onBehalfOf(first: 5) {
+        nodes {
+          slug
+        }
+      }
+    }
+  }
+  reviewRequests(first: 20) {
+    nodes {
+      requestedReviewer {
+        ... on Team {
+          slug
+        }
+      }
+    }
+  }
+
+  # Build statuses
+  commits(last: 1) {
+    nodes {
+      commit {
+        statusCheckRollup {
+          ...statusCheckRollup
+        }
+      }
+    }
+  }
+}
+
+${statusCheckRollupFragment}
+`
+
+export interface PullRequestFragment {
+  id: string;
+  isDraft: boolean;
+  number: number;
+  title: string;
+  url: string;
+  baseRepository: {
+    name: string;
+    owner: {
+      login: string;
+    };
+  };
+  reviews: {
+    nodes: {
+      author: {
+        login: string;
+      };
+      state: ReviewState;
+      onBehalfOf: {
+        nodes: {
+          slug: string;
+        }[];
+      };
+    }[];
+  };
+  reviewRequests: {
+    nodes: {
+      requestedReviewer: {
+        slug?: string;
+      };
+    }[];
+  };
+  commits: {
+    nodes: {
+      commit: {
+        statusCheckRollup?: StatusCheckRollupFragment;
+      };
+    }[];
+  };
+}

--- a/lib/service/queries/pullRequestSearch.ts
+++ b/lib/service/queries/pullRequestSearch.ts
@@ -1,111 +1,22 @@
-import {ReviewState} from "../../model/review.js";
 import {
-  StatusCheckRollupFragment,
-  statusCheckRollupFragment,
-} from "./statusCheckRollupFragment.js";
+  PullRequestFragment,
+  pullRequestFragment,
+} from "./pullRequestFragment.js"
 
 export const pullRequestSearchQuery = `
 query($search: String!, $rollupCursor: String) {
   search(query: $search, first: 30, type: ISSUE) {
     nodes {
-      ... on PullRequest {
-        id
-        isDraft
-        number
-        title
-        url
-        baseRepository {
-          name
-          owner {
-            login
-          }
-        }
-
-        # Reviews
-
-        reviews(first: 20) {
-          nodes {
-            author {
-              login
-            }
-            state
-            onBehalfOf(first: 5) {
-              nodes {
-                slug
-              }
-            }
-          }
-        }
-        reviewRequests(first: 20) {
-          nodes {
-            requestedReviewer {
-              ... on Team {
-                slug
-              }
-            }
-          }
-        }
-
-        # Build statuses
-        commits(last: 1) {
-          nodes {
-            commit {
-              statusCheckRollup {
-                ...statusCheckRollup
-              }
-            }
-          }
-        }
-
-      }
+      ...pullRequestFragment
     }
   }
 }
 
-${statusCheckRollupFragment}
+${pullRequestFragment}
 `;
 
 export interface PullRequestSearchResponse {
   search: {
-    nodes: {
-      id: string;
-      isDraft: boolean;
-      number: number;
-      title: string;
-      url: string;
-      baseRepository: {
-        name: string;
-        owner: {
-          login: string;
-        };
-      };
-      reviews: {
-        nodes: {
-          author: {
-            login: string;
-          };
-          state: ReviewState;
-          onBehalfOf: {
-            nodes: {
-              slug: string;
-            }[];
-          };
-        }[];
-      };
-      reviewRequests: {
-        nodes: {
-          requestedReviewer: {
-            slug?: string;
-          };
-        }[];
-      };
-      commits: {
-        nodes: {
-          commit: {
-            statusCheckRollup?: StatusCheckRollupFragment;
-          };
-        }[];
-      };
-    }[];
+    nodes: PullRequestFragment[],
   };
 }

--- a/lib/service/queries/pullRequestSearch.ts
+++ b/lib/service/queries/pullRequestSearch.ts
@@ -1,7 +1,7 @@
 import {
   PullRequestFragment,
   pullRequestFragment,
-} from "./pullRequestFragment.js"
+} from "./pullRequestFragment.js";
 
 export const pullRequestSearchQuery = `
 query($search: String!, $rollupCursor: String) {
@@ -17,6 +17,6 @@ ${pullRequestFragment}
 
 export interface PullRequestSearchResponse {
   search: {
-    nodes: PullRequestFragment[],
+    nodes: PullRequestFragment[];
   };
 }

--- a/test/helpers/builders/responses/pullRequestByNumberBuilders.ts
+++ b/test/helpers/builders/responses/pullRequestByNumberBuilders.ts
@@ -1,0 +1,14 @@
+import {createBuilderClass} from "nested-builder";
+import {PullRequestByNumberResponse} from "../../../../lib/service/queries/pullRequestByNumber.js";
+import {PullRequestFragmentBuilder} from "./pullRequestFragmentBuilders.js";
+
+export const PullRequestByNumberBuilder =
+  createBuilderClass<PullRequestByNumberResponse>()({
+    repository: {
+      nested: createBuilderClass<PullRequestByNumberResponse["repository"]>()({
+        pullRequest: {
+          nested: PullRequestFragmentBuilder,
+        },
+      }),
+    },
+  });

--- a/test/helpers/builders/responses/pullRequestFragmentBuilders.ts
+++ b/test/helpers/builders/responses/pullRequestFragmentBuilders.ts
@@ -1,0 +1,89 @@
+import {createBuilderClass} from "nested-builder";
+import {PullRequestFragment} from "../../../../lib/service/queries/pullRequestFragment.js";
+import {StatusCheckRollupFragmentBuilder} from "./statusCheckRollupFragmentBuilders.js";
+
+type BaseRepositoryNode = PullRequestFragment["baseRepository"];
+type ReviewNode = PullRequestFragment["reviews"]["nodes"][number];
+type ReviewRequestNode = PullRequestFragment["reviewRequests"]["nodes"][number];
+type CommitNode = PullRequestFragment["commits"]["nodes"][number];
+
+const CommitNodeBuilder = createBuilderClass<CommitNode>()({
+  commit: {
+    nested: createBuilderClass<CommitNode["commit"]>()({
+      statusCheckRollup: {
+        nested: StatusCheckRollupFragmentBuilder,
+      },
+    }),
+  },
+});
+
+export const PullRequestFragmentBuilder =
+  createBuilderClass<PullRequestFragment>()({
+    id: {default: "SRC000"},
+    isDraft: {default: false},
+    number: {default: 1},
+    title: {default: "Pull Request Title"},
+    url: {default: "https://github.com/owner/repo/pulls/1"},
+    baseRepository: {
+      nested: createBuilderClass<BaseRepositoryNode>()({
+        name: {default: "repo"},
+        owner: {
+          nested: createBuilderClass<BaseRepositoryNode["owner"]>()({
+            login: {default: "owner"},
+          }),
+        },
+      }),
+    },
+    reviews: {
+      nested: createBuilderClass<PullRequestFragment["reviews"]>()({
+        nodes: {
+          plural: true,
+          nested: createBuilderClass<ReviewNode>()({
+            author: {
+              nested: createBuilderClass<ReviewNode["author"]>()({
+                login: {default: "reviewer"},
+              }),
+            },
+            state: {default: "COMMENTED"},
+            onBehalfOf: {
+              nested: createBuilderClass<ReviewNode["onBehalfOf"]>()({
+                nodes: {
+                  plural: true,
+                  nested: createBuilderClass<
+                    ReviewNode["onBehalfOf"]["nodes"][number]
+                  >()({
+                    slug: {default: "requested-team-slug"},
+                  }),
+                },
+              }),
+            },
+          }),
+        },
+      }),
+    },
+    reviewRequests: {
+      nested: createBuilderClass<PullRequestFragment["reviewRequests"]>()({
+        nodes: {
+          plural: true,
+          nested: createBuilderClass<ReviewRequestNode>()({
+            requestedReviewer: {
+              nested: createBuilderClass<
+                ReviewRequestNode["requestedReviewer"]
+              >()({
+                slug: {default: "requested-team-slug"},
+              }),
+            },
+          }),
+        },
+      }),
+    },
+    commits: {
+      nested: createBuilderClass<PullRequestFragment["commits"]>()({
+        nodes: {
+          plural: true,
+          nested: CommitNodeBuilder,
+          default: [new CommitNodeBuilder().build()],
+        },
+      }),
+    },
+  });

--- a/test/helpers/builders/responses/pullRequestSearchBuilders.ts
+++ b/test/helpers/builders/responses/pullRequestSearchBuilders.ts
@@ -1,22 +1,6 @@
 import {createBuilderClass} from "nested-builder";
 import {PullRequestSearchResponse} from "../../../../lib/service/queries/pullRequestSearch.js";
-import {StatusCheckRollupFragmentBuilder} from "./statusCheckRollupFragmentBuilders.js";
-
-type PullRequestNode = PullRequestSearchResponse["search"]["nodes"][number];
-type BaseRepositoryNode = PullRequestNode["baseRepository"];
-type ReviewNode = PullRequestNode["reviews"]["nodes"][number];
-type ReviewRequestNode = PullRequestNode["reviewRequests"]["nodes"][number];
-type CommitNode = PullRequestNode["commits"]["nodes"][number];
-
-const CommitNodeBuilder = createBuilderClass<CommitNode>()({
-  commit: {
-    nested: createBuilderClass<CommitNode["commit"]>()({
-      statusCheckRollup: {
-        nested: StatusCheckRollupFragmentBuilder,
-      },
-    }),
-  },
-});
+import {PullRequestFragmentBuilder} from "./pullRequestFragmentBuilders.js";
 
 export const PullRequestSearchBuilder =
   createBuilderClass<PullRequestSearchResponse>()({
@@ -24,75 +8,7 @@ export const PullRequestSearchBuilder =
       nested: createBuilderClass<PullRequestSearchResponse["search"]>()({
         nodes: {
           plural: true,
-          nested: createBuilderClass<PullRequestNode>()({
-            id: {default: "SRC000"},
-            isDraft: {default: false},
-            number: {default: 1},
-            title: {default: "Pull Request Title"},
-            url: {default: "https://github.com/owner/repo/pulls/1"},
-            baseRepository: {
-              nested: createBuilderClass<BaseRepositoryNode>()({
-                name: {default: "repo"},
-                owner: {
-                  nested: createBuilderClass<BaseRepositoryNode["owner"]>()({
-                    login: {default: "owner"},
-                  }),
-                },
-              }),
-            },
-            reviews: {
-              nested: createBuilderClass<PullRequestNode["reviews"]>()({
-                nodes: {
-                  plural: true,
-                  nested: createBuilderClass<ReviewNode>()({
-                    author: {
-                      nested: createBuilderClass<ReviewNode["author"]>()({
-                        login: {default: "reviewer"},
-                      }),
-                    },
-                    state: {default: "COMMENTED"},
-                    onBehalfOf: {
-                      nested: createBuilderClass<ReviewNode["onBehalfOf"]>()({
-                        nodes: {
-                          plural: true,
-                          nested: createBuilderClass<
-                            ReviewNode["onBehalfOf"]["nodes"][number]
-                          >()({
-                            slug: {default: "requested-team-slug"},
-                          }),
-                        },
-                      }),
-                    },
-                  }),
-                },
-              }),
-            },
-            reviewRequests: {
-              nested: createBuilderClass<PullRequestNode["reviewRequests"]>()({
-                nodes: {
-                  plural: true,
-                  nested: createBuilderClass<ReviewRequestNode>()({
-                    requestedReviewer: {
-                      nested: createBuilderClass<
-                        ReviewRequestNode["requestedReviewer"]
-                      >()({
-                        slug: {default: "requested-team-slug"},
-                      }),
-                    },
-                  }),
-                },
-              }),
-            },
-            commits: {
-              nested: createBuilderClass<PullRequestNode["commits"]>()({
-                nodes: {
-                  plural: true,
-                  nested: CommitNodeBuilder,
-                  default: [new CommitNodeBuilder().build()],
-                },
-              }),
-            },
-          }),
+          nested: PullRequestFragmentBuilder,
         },
       }),
     },

--- a/test/invocation.test.ts
+++ b/test/invocation.test.ts
@@ -3,8 +3,10 @@ import {fileURLToPath} from "url";
 import {Invocation} from "../lib/invocation.js";
 import {pullRequestSearchQuery} from "../lib/service/queries/pullRequestSearch.js";
 import {PullRequestSearchBuilder} from "./helpers/builders/responses/pullRequestSearchBuilders.js";
+import {PullRequestByNumberBuilder} from "./helpers/builders/responses/pullRequestByNumberBuilders.js";
 import {CannedGraphQL} from "./helpers/cannedGraphQL.js";
 import {StringBuffer} from "./helpers/stringBuffer.js";
+import {pullRequestByNumberQuery} from "../lib/service/queries/pullRequestByNumber.js";
 
 describe("Invocation", function () {
   function args(...args: string[]) {
@@ -156,6 +158,12 @@ describe("Invocation", function () {
         })
         .build();
 
+      const byNumberResponse = new PullRequestByNumberBuilder()
+        .repository((repoB) => {
+          repoB.pullRequest((prB) => prB.title("Three"));
+        })
+        .build();
+
       graphQL.expect(
         pullRequestSearchQuery,
         {
@@ -165,12 +173,22 @@ describe("Invocation", function () {
         searchResponse
       );
 
+      graphQL.expect(
+        pullRequestByNumberQuery,
+        {
+          owner: "the-owner",
+          name: "a-name",
+          number: 123,
+        },
+        byNumberResponse
+      );
+
       const i = new Invocation(
         graphQL,
         output,
         "TOKEN",
         ["aaa/repo0", "aaa/repo1"],
-        [],
+        [{owner: "the-owner", name: "a-name", number: 123}],
         false,
         false
       );
@@ -179,6 +197,7 @@ describe("Invocation", function () {
       assert.match(output.contents, /Zero/);
       assert.match(output.contents, /One/);
       assert.match(output.contents, /Two/);
+      assert.match(output.contents, /Three/);
     });
   });
 });

--- a/test/service/pullRequestLocator.test.ts
+++ b/test/service/pullRequestLocator.test.ts
@@ -18,6 +18,8 @@ import {
   StatusContextBuilder,
 } from "../helpers/builders/responses/statusCheckRollupFragmentBuilders.js";
 import {CannedGraphQL} from "../helpers/cannedGraphQL.js";
+import {pullRequestByNumberQuery} from "../../lib/service/queries/pullRequestByNumber.js";
+import {PullRequestByNumberBuilder} from "../helpers/builders/responses/pullRequestByNumberBuilders.js";
 
 describe("PullRequestLocator", function () {
   let graphQL: CannedGraphQL;
@@ -57,6 +59,30 @@ describe("PullRequestLocator", function () {
 
       const pullRequests = await locator.inRepositories(["aaa/bbb"]);
       assert.isEmpty(pullRequests);
+    });
+  });
+
+  describe("number query", function () {
+    it("queries for a specific pull request", async function () {
+      const response = new PullRequestByNumberBuilder().repository((repoB) => {
+        repoB.pullRequest((prB) => {
+          prB.id("PR0");
+        });
+      }).build();
+
+      graphQL.expect(
+        pullRequestByNumberQuery,
+        {
+          owner: "owner",
+          name: "name",
+          number: 123,
+        },
+        response
+      );
+
+      const pr = await locator.byNumber("owner", "name", 123);
+      assert.isNotNull(pr);
+      assert.strictEqual(pr!.id, "PR0");
     });
   });
 

--- a/test/service/pullRequestLocator.test.ts
+++ b/test/service/pullRequestLocator.test.ts
@@ -78,6 +78,7 @@ describe("PullRequestLocator", function () {
           owner: "owner",
           name: "name",
           number: 123,
+          rollupCursor: null,
         },
         response
       );

--- a/test/service/pullRequestLocator.test.ts
+++ b/test/service/pullRequestLocator.test.ts
@@ -64,11 +64,13 @@ describe("PullRequestLocator", function () {
 
   describe("number query", function () {
     it("queries for a specific pull request", async function () {
-      const response = new PullRequestByNumberBuilder().repository((repoB) => {
-        repoB.pullRequest((prB) => {
-          prB.id("PR0");
-        });
-      }).build();
+      const response = new PullRequestByNumberBuilder()
+        .repository((repoB) => {
+          repoB.pullRequest((prB) => {
+            prB.id("PR0");
+          });
+        })
+        .build();
 
       graphQL.expect(
         pullRequestByNumberQuery,


### PR DESCRIPTION
Fixes #77.

Add a `-p`/`--pull-request` command line option, repeatable, that allows you to specify one or more PRs to watch individually.