### PR TITLE
Customize the number of visible builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If omitted and a `GITHUB_REPOSITORY` environment variable is present and non-emp
 Otherwise, here's the usage:
 
 ```
-Usage: pr status [options] [command]
+Usage: pr-status [options] [command]
 
 Commands:
   help     Display help

--- a/README.md
+++ b/README.md
@@ -25,18 +25,19 @@ If omitted and a `GITHUB_REPOSITORY` environment variable is present and non-emp
 Otherwise, here's the usage:
 
 ```
-Usage: pr-status [options] [command]
+Usage: pr status [options] [command]
 
 Commands:
   help     Display help
   version  Display version
 
 Options:
-  -h, --help         Output usage information
+  -h, --help                 Output usage information
+  -n, --num-builds <n>       Number of builds to show (defaults to 10)
   -p, --pull-request <list>  Limit results to individually identified pull requests (defaults to [])
-  -r, --repo <list>  Limit results to PRs in this repo (defaults to [])
-  -t, --token        GitHub API token used for queries (defaults to "")
-  -v, --verbose      Include successful builds in output (disabled by default)
-  -V, --version      Output the version number
-  -w, --wait         Poll for updates (disabled by default)
+  -r, --repo <list>          Limit results to PRs in this repo (defaults to [])
+  -t, --token                GitHub API token used for queries (defaults to "")
+  -v, --verbose              Include successful builds in output (disabled by default)
+  -V, --version              Output the version number
+  -w, --wait                 Poll for updates (disabled by default)
 ```

--- a/lib/formatter/pullRequestFormatter.ts
+++ b/lib/formatter/pullRequestFormatter.ts
@@ -5,10 +5,12 @@ import {Formatter} from "./formatter.js";
 export class PullRequestFormatter implements Formatter {
   pullRequest: PullRequest;
   verbose: boolean;
+  buildsToShow: number;
 
-  constructor(pullRequest: PullRequest, verbose: boolean) {
+  constructor(pullRequest: PullRequest, verbose: boolean, buildsToShow: number) {
     this.pullRequest = pullRequest;
     this.verbose = verbose;
+    this.buildsToShow = buildsToShow;
   }
 
   string(): string {
@@ -67,7 +69,7 @@ export class PullRequestFormatter implements Formatter {
       : this.pullRequest.statuses.filter(
           (status) => status.isPending() || status.isFailed()
         );
-    const visibleBuilds = includedBuilds.slice(0, 15);
+    const visibleBuilds = includedBuilds.slice(0, this.buildsToShow);
 
     const hiddenBuilds = new Set(this.pullRequest.statuses);
     for (const build of visibleBuilds) {

--- a/lib/formatter/pullRequestFormatter.ts
+++ b/lib/formatter/pullRequestFormatter.ts
@@ -7,7 +7,11 @@ export class PullRequestFormatter implements Formatter {
   verbose: boolean;
   buildsToShow: number;
 
-  constructor(pullRequest: PullRequest, verbose: boolean, buildsToShow: number) {
+  constructor(
+    pullRequest: PullRequest,
+    verbose: boolean,
+    buildsToShow: number
+  ) {
     this.pullRequest = pullRequest;
     this.verbose = verbose;
     this.buildsToShow = buildsToShow;

--- a/lib/invocation.ts
+++ b/lib/invocation.ts
@@ -214,7 +214,9 @@ export class Invocation {
     return this.write(
       pullRequests
         .map(
-          (pullRequest) => pullRequest.formatter(this.verbose, this.buildsToShow).string() + "\n"
+          (pullRequest) =>
+            pullRequest.formatter(this.verbose, this.buildsToShow).string() +
+            "\n"
         )
         .join("\n")
     );

--- a/lib/invocation.ts
+++ b/lib/invocation.ts
@@ -28,6 +28,7 @@ export class Invocation {
   pullRequests: PullRequestDesignator[];
   wait: boolean;
   verbose: boolean;
+  buildsToShow: number;
   graphql: GraphQL;
   output: OutputWriter;
 
@@ -38,13 +39,15 @@ export class Invocation {
     repos: string[] = [],
     pullRequests: PullRequestDesignator[] = [],
     wait: false,
-    verbose: false
+    verbose: false,
+    buildsToShow: number
   ) {
     this.token = token;
     this.repos = repos;
     this.pullRequests = pullRequests;
     this.wait = wait;
     this.verbose = verbose;
+    this.buildsToShow = buildsToShow;
     this.graphql = graphql;
     this.output = output;
   }
@@ -58,6 +61,7 @@ export class Invocation {
         "Limit results to individually identified pull requests",
         []
       )
+      .option(["n", "num-builds"], "Number of builds to show", 10)
       .option(["w", "wait"], "Poll for updates", false)
       .option(["v", "verbose"], "Include successful builds in output", false);
     const flags = args.parse(argv);
@@ -108,7 +112,8 @@ export class Invocation {
       repos,
       pullRequests,
       flags.wait,
-      flags.verbose
+      flags.verbose,
+      flags.n
     );
   }
 

--- a/lib/invocation.ts
+++ b/lib/invocation.ts
@@ -214,7 +214,7 @@ export class Invocation {
     return this.write(
       pullRequests
         .map(
-          (pullRequest) => pullRequest.formatter(this.verbose).string() + "\n"
+          (pullRequest) => pullRequest.formatter(this.verbose, this.buildsToShow).string() + "\n"
         )
         .join("\n")
     );

--- a/lib/model/pullRequest.ts
+++ b/lib/model/pullRequest.ts
@@ -82,7 +82,7 @@ export class PullRequest {
     return this.requestedReviews.length;
   }
 
-  formatter(verbose: boolean): Formatter {
-    return new PullRequestFormatter(this, verbose);
+  formatter(verbose: boolean, buildsToShow: number): Formatter {
+    return new PullRequestFormatter(this, verbose, buildsToShow);
   }
 }

--- a/test/formatters/pullRequestFormatter.test.ts
+++ b/test/formatters/pullRequestFormatter.test.ts
@@ -13,7 +13,7 @@ describe("PullRequestFormatter", function () {
       title: "Mock Pull Request Data",
       isDraft: true,
     });
-    const formatted = pr.formatter(false).string();
+    const formatted = pr.formatter(false, 10).string();
 
     assert.strictEqual(
       formatted,
@@ -30,7 +30,7 @@ describe("PullRequestFormatter", function () {
       title: "More Pull Request Data",
       isDraft: false,
     });
-    const formatted = pr.formatter(false).string();
+    const formatted = pr.formatter(false, 10).string();
 
     assert.strictEqual(
       formatted,
@@ -92,7 +92,7 @@ describe("PullRequestFormatter", function () {
       statuses,
       requestedReviews,
     });
-    const formatted = pr.formatter(false).string();
+    const formatted = pr.formatter(false, 10).string();
 
     assert.strictEqual(
       formatted,
@@ -164,7 +164,7 @@ describe("PullRequestFormatter", function () {
       statuses,
       requestedReviews,
     });
-    const formatted = pr.formatter(true).string();
+    const formatted = pr.formatter(true, 10).string();
 
     assert.strictEqual(
       formatted,
@@ -212,7 +212,7 @@ describe("PullRequestFormatter", function () {
       statuses,
       requestedReviews,
     });
-    const formatted = pr.formatter(false).string();
+    const formatted = pr.formatter(false, 10).string();
 
     assert.strictEqual(
       formatted,
@@ -254,7 +254,7 @@ describe("PullRequestFormatter", function () {
       statuses,
       requestedReviews,
     });
-    const formatted = pr.formatter(true).string();
+    const formatted = pr.formatter(true, 10).string();
 
     assert.strictEqual(
       formatted,
@@ -264,6 +264,76 @@ describe("PullRequestFormatter", function () {
         "  ✅ suite / run [success]",
         "  ✅ context [success]",
         "  ✅ malachite: @reviewer0",
+      ].join("\n")
+    );
+  });
+
+  it("renders a pull request with a specified number of visible builds", function () {
+    const statuses = [
+      buildCheckRunStatus({
+        status: "PENDING",
+        suiteName: "suite",
+        runName: "status0",
+      }),
+      buildCheckRunStatus({
+        status: "COMPLETED",
+        conclusion: "SUCCESS",
+        suiteName: "suite",
+        runName: "status1",
+      }),
+      buildCheckRunStatus({
+        status: "COMPLETED",
+        conclusion: "FAILURE",
+        suiteName: "suite",
+        runName: "status2",
+        url: "https://check-run.org/failed",
+      }),
+      buildContextStatus({
+        context: "status3",
+        state: "PENDING",
+      }),
+      buildContextStatus({
+        context: "status4",
+        state: "SUCCESS",
+      }),
+      buildContextStatus({
+        context: "status5",
+        state: "FAILURE",
+        url: "https://context.net/failed",
+      }),
+    ];
+
+    const requestedReviews = [
+      buildRequestedReview({teamName: "slate"}),
+      buildRequestedReview({
+        teamName: "talc",
+        receivedReviews: [
+          buildReview({reviewer: "reviewer0", state: "APPROVED"}),
+        ],
+      }),
+    ];
+
+    const pr = buildPullRequest({
+      url: "https://github.com/smashwilson/pr-status/pulls/3",
+      title: "Truncated Pull Request Data",
+      statuses,
+      requestedReviews,
+    });
+    const formatted = pr.formatter(true, 3).string();
+
+    assert.strictEqual(
+      formatted,
+      [
+        chalk.underline("https://github.com/smashwilson/pr-status/pulls/3"),
+        chalk.bold("Truncated Pull Request Data") +
+          " [builds 2 / 6] [reviews 1 / 2]",
+        "  ⏳ suite / status0",
+        "  ✅ suite / status1 [success]",
+        "  ❌ suite / status2 [failure] " +
+          chalk.underline("https://check-run.org/failed"),
+        "  [+ 1 pending 1 failed 1 succeeded builds]",
+        "  ⏳ slate",
+        "  ✅ talc: @reviewer0",
       ].join("\n")
     );
   });

--- a/test/invocation.test.ts
+++ b/test/invocation.test.ts
@@ -147,7 +147,7 @@ describe("Invocation", function () {
     it("accepts the number of builds to show with the -n flag", function () {
       const i = Invocation.configuredFrom(
         args("-n", "17", "--repo", "smashwilson/pr-status"),
-        {GITHUB_TOKEN: "RIGHTTOKEN"},
+        {GITHUB_TOKEN: "RIGHTTOKEN"}
       );
       assert.strictEqual(17, i.buildsToShow);
     });
@@ -155,7 +155,7 @@ describe("Invocation", function () {
     it("defaults to 10 visible builds", function () {
       const i = Invocation.configuredFrom(
         args("--repo", "smashwilson/pr-status"),
-        {GITHUB_TOKEN: "RIGHTTOKEN"},
+        {GITHUB_TOKEN: "RIGHTTOKEN"}
       );
       assert.strictEqual(10, i.buildsToShow);
     });
@@ -207,7 +207,7 @@ describe("Invocation", function () {
         [{owner: "the-owner", name: "a-name", number: 123}],
         false,
         false,
-        10,
+        10
       );
       await i.execute();
 

--- a/test/invocation.test.ts
+++ b/test/invocation.test.ts
@@ -143,6 +143,22 @@ describe("Invocation", function () {
         {owner: "wat", name: "huh", number: 123},
       ]);
     });
+
+    it("accepts the number of builds to show with the -n flag", function () {
+      const i = Invocation.configuredFrom(
+        args("-n", "17", "--repo", "smashwilson/pr-status"),
+        {GITHUB_TOKEN: "RIGHTTOKEN"},
+      );
+      assert.strictEqual(17, i.buildsToShow);
+    });
+
+    it("defaults to 10 visible builds", function () {
+      const i = Invocation.configuredFrom(
+        args("--repo", "smashwilson/pr-status"),
+        {GITHUB_TOKEN: "RIGHTTOKEN"},
+      );
+      assert.strictEqual(10, i.buildsToShow);
+    });
   });
 
   describe("report", function () {
@@ -190,7 +206,8 @@ describe("Invocation", function () {
         ["aaa/repo0", "aaa/repo1"],
         [{owner: "the-owner", name: "a-name", number: 123}],
         false,
-        false
+        false,
+        10,
       );
       await i.execute();
 


### PR DESCRIPTION
Adds a `-n` or `--num-builds` option that allows you to control how many builds are visible in the command output.